### PR TITLE
Add carousel image assets directory

### DIFF
--- a/src/assets/carousel/.gitkeep
+++ b/src/assets/carousel/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder file to keep the carousel images directory tracked by git.


### PR DESCRIPTION
## Summary
- add a dedicated `src/assets/carousel` folder for carousel images
- include a `.gitkeep` so the directory is tracked in git

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce389f626083338d6c76beb88226cf