### PR TITLE
Use docs directory for Pages artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - run: npm ci || npm i
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
-        with: { path: ./dist }
+        with: { path: ./docs }
   deploy:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- update the deploy workflow to upload the docs directory for the Pages artifact

## Testing
- not run (workflow dispatch requires GitHub Actions)


------
https://chatgpt.com/codex/tasks/task_e_68ce3d78d6008333a8c113b6a772b502