### PR TITLE
Set Vite base to relative path

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Реверсивный инжиниринг и АТ — РГСУ × STEP_3D</title>
     <meta name="description" content="Практический интенсив: 3D-сканирование → реверс в CAD → печать оснастки." />
-    <script type="module" crossorigin src="/AT.R22/assets/index-FBp5AItf.js"></script>
-    <link rel="stylesheet" crossorigin href="/AT.R22/assets/index-Cf4C7L5Q.css">
+    <script type="module" crossorigin src="./assets/index-FBp5AItf.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-Cf4C7L5Q.css">
   </head>
   <body class="min-h-screen bg-white text-neutral-900 selection:bg-black selection:text-white">
     <div id="root"></div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/AT.R22/',   // ← имя репозитория ТОЧНО с тем же регистром
+  base: './',
   build: {
     outDir: 'docs',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- update the Vite configuration to use a relative `base` path
- rebuild the production bundle so the generated docs reference assets with relative URLs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ce3f9d5ec883338bc727b57cbfb745